### PR TITLE
feat: add Black Friday integration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -71,6 +71,7 @@ function define_constants() {
 	define( 'NON_PROFIT_FSE_DEBUG', defined( 'WP_DEBUG' ) && WP_DEBUG === true );
 	define( 'NON_PROFIT_FSE_DIR', trailingslashit( get_template_directory() ) );
 	define( 'NON_PROFIT_FSE_URL', trailingslashit( get_template_directory_uri() ) );
+	define( 'NON_PROFIT_FSE_PRODUCT_SLUG', basename( NON_PROFIT_FSE_DIR ) );
 }
 
 /**


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Add Black Friday integration.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots 
<!-- if applicable -->

![CleanShot 2025-05-16 at 16 57 24@2x](https://github.com/user-attachments/assets/7fbbd82d-dbc6-4e0a-b644-0db8d8dfd7f7)


### Test instructions
<!-- Describe how this pull request can be tested. -->
- [USE THIS SDK VERSION as PLUGIN](https://github.com/Codeinwp/themeisle-sdk-main/pull/295#issuecomment-2858057844)
- Alter the date to fall into the Black Friday sales period.

You can use this hook to alternate it:

```php
add_filter(
	'themeisle_sdk_current_date',
	function() {
		return new DateTime( '2025-11-26' );
	}
);
```

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->