### PR TITLE
Fixed banner overflow

### DIFF
--- a/assets/css/src/common/_generic.scss
+++ b/assets/css/src/common/_generic.scss
@@ -69,6 +69,11 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	width: unset;
 }
 
+.wp-site-blocks .wp-block-cover.alignfull {
+	margin-left: 0 !important;
+	margin-right: 0 !important;
+}
+
 /**
  * Override button outline paddings because they
  * can NOT be changed from the theme.json.


### PR DESCRIPTION
### Summary
Fixed the margin of the cover block when it's set to alignfull.

Closes https://github.com/Codeinwp/non-profit-fse/issues/15